### PR TITLE
libuv 1.52.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libuv" %}
-{% set version = "1.52.0" %}
+{% set version = "1.52.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: eee139c05f7c868f5ae7a54b1e155fd5b6ed13a22329958d2ba711faad016353
+  sha256: 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c
   patches:
     - 0001-Skip-the-single-bit-that-fails-in-test-fs-copyfile-w.patch
 
@@ -20,27 +20,27 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    - automake             # [unix]
-    - autoconf             # [unix]
-    - libtool              # [unix]
-    - make                 # [unix]
-    - sed                  # [unix]
-    - cmake-no-system      # [win]
-    - ninja-base           # [win]
+    - automake  # [unix]
+    - autoconf  # [unix]
+    - libtool  # [unix]
+    - make  # [unix]
+    - sed  # [unix]
+    - cmake-no-system  # [win]
+    - ninja-base  # [win]
 
 test:
   commands:
-    - test -f "$PREFIX/include/uv.h"                # [unix]
-    - test -f "$PREFIX/lib/libuv.a"                 # [unix]
-    - test -f "$PREFIX/lib/libuv.so.1"              # [linux]
-    - test -f "$PREFIX/lib/libuv.1.dylib"           # [osx]
-    - test -f "$PREFIX/lib/libuv${SHLIB_EXT}"       # [not win]
-    - test -f "$PREFIX/lib/pkgconfig/libuv.pc"      # [not win]
-    - if not exist %LIBRARY_INC%\uv.h (exit 1)      # [win]
-    - if not exist %LIBRARY_LIB%\uv.lib (exit 1)    # [win]
-    - if not exist %LIBRARY_BIN%\uv.dll (exit 1)    # [win]
+    - test -f "$PREFIX/include/uv.h"  # [unix]
+    - test -f "$PREFIX/lib/libuv.a"  # [unix]
+    - test -f "$PREFIX/lib/libuv.so.1"  # [linux]
+    - test -f "$PREFIX/lib/libuv.1.dylib"  # [osx]
+    - test -f "$PREFIX/lib/libuv${SHLIB_EXT}"  # [not win]
+    - test -f "$PREFIX/lib/pkgconfig/libuv.pc"  # [not win]
+    - if not exist %LIBRARY_INC%\uv.h (exit 1)  # [win]
+    - if not exist %LIBRARY_LIB%\uv.lib (exit 1)  # [win]
+    - if not exist %LIBRARY_BIN%\uv.dll (exit 1)  # [win]
     - if not exist %LIBRARY_LIB%\pkgconfig/libuv-static.pc (exit 1)  # [win]
-    - if not exist %LIBRARY_LIB%\pkgconfig/libuv.pc (exit 1)         # [win]
+    - if not exist %LIBRARY_LIB%\pkgconfig/libuv.pc (exit 1)  # [win]
 
 about:
   home: https://libuv.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ stdlib('c') }}
+    - {{ compiler('c') }}
     - automake  # [unix]
     - autoconf  # [unix]
     - libtool  # [unix]


### PR DESCRIPTION
libuv 1.52.1 

**Destination channel:** Defaults

### Links

- [PKG-16503]
- dev_url:        https://github.com/libuv/libuv/tree/v1.52.1
- conda_forge:    https://github.com/conda-forge/libuv-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-16503]: https://anaconda.atlassian.net/browse/PKG-16503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ